### PR TITLE
FIx setup.py

### DIFF
--- a/openpiv/docs/sphinx-docs/src/generated/openpiv.pyprocess.demean.rst
+++ b/openpiv/docs/sphinx-docs/src/generated/openpiv.pyprocess.demean.rst
@@ -1,6 +1,0 @@
-openpiv.pyprocess.demean
-========================
-
-.. currentmodule:: openpiv.pyprocess
-
-.. autofunction:: demean

--- a/openpiv/docs/sphinx-docs/src/generated/openpiv.pyprocess.find_pixel_peak_position.rst
+++ b/openpiv/docs/sphinx-docs/src/generated/openpiv.pyprocess.find_pixel_peak_position.rst
@@ -1,6 +1,6 @@
 openpiv.pyprocess.find_pixel_peak_position
 ==========================================
 
-.. currentmodule:: openpiv
+.. currentmodule:: openpiv.pyprocess
 
-.. automethod:: pyprocess.find_pixel_peak_position
+.. autofunction:: find_pixel_peak_position

--- a/openpiv/docs/sphinx-docs/src/generated/openpiv.pyprocess.normalize_intensity.rst
+++ b/openpiv/docs/sphinx-docs/src/generated/openpiv.pyprocess.normalize_intensity.rst
@@ -1,6 +1,6 @@
 openpiv.pyprocess.normalize_intensity
 =====================================
 
-.. currentmodule:: openpiv
+.. currentmodule:: openpiv.pyprocess
 
-.. automethod:: pyprocess.normalize_intensity
+.. autofunction:: normalize_intensity

--- a/openpiv/docs/sphinx-docs/src/generated/openpiv.pyprocess.signal_noise_ratio.rst
+++ b/openpiv/docs/sphinx-docs/src/generated/openpiv.pyprocess.signal_noise_ratio.rst
@@ -1,6 +1,0 @@
-openpiv.pyprocess.signal_noise_ratio
-====================================
-
-.. currentmodule:: openpiv.pyprocess
-
-.. autofunction:: signal_noise_ratio

--- a/openpiv/docs/sphinx-docs/src/generated/openpiv.validation.global_val.rst
+++ b/openpiv/docs/sphinx-docs/src/generated/openpiv.validation.global_val.rst
@@ -1,0 +1,6 @@
+openpiv.validation.global_val
+=============================
+
+.. currentmodule:: openpiv.validation
+
+.. autofunction:: global_val

--- a/openpiv/docs/sphinx-docs/src/generated/openpiv.validation.sig2noise_val.rst
+++ b/openpiv/docs/sphinx-docs/src/generated/openpiv.validation.sig2noise_val.rst
@@ -1,0 +1,6 @@
+openpiv.validation.sig2noise_val
+================================
+
+.. currentmodule:: openpiv.validation
+
+.. autofunction:: sig2noise_val

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ module1 = Extension(    name         = "openpiv.process",
                     )
 
 # a list of the extension modules that we want to distribute
-ext_modules = []
+ext_modules = [module1]
 
 
 # Package data are those filed 'strictly' needed by the program


### PR DESCRIPTION
Alex,

I have fixed the setup.py script which did not compile the .c file.  Also fixed some documentation issues.

Please note that before building OpenPiv you should give the command `cython process.pyx` in the openpiv/src directory to generate a process.c file, which is then compiled automatically. It would be possible to modify the setup.py script so that this is done automatically at build time, but in this way the users have to have cython installed. For this reason, when every .pyx file is modified it must be cythonized, to update the c file. 

What to you think? Do you prefer that cython is run at build time and users have to install cython too?

Regards,

Davide
