### PR TITLE
Drop MANIFEST inclusion

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,7 +3,6 @@ include *.sh
 include *.txt
 include INSTALL
 include LICENSE.txt
-include MANIFEST
 include MILESTONES
 include TODO
 recursive-include openpiv *.bat


### PR DESCRIPTION
Drops `MANIFEST` from `MANIFEST.in`. This seems a bit circular, but maybe I'm missing something here.