### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ module1 = Extension(    name         = "openpiv.process",
                     
 module2 = Extension(    name         = "openpiv.lib",
                         sources      = ["openpiv/src/lib.pyx"],
-                        libraries    = ["m"],
                         include_dirs = [numpy.get_include()],
                     )
 


### PR DESCRIPTION
Appveyor fails to build the openpiv-python due to the missing 'm.lib' - maybe it is not necessary anymore