### PR TITLE
updated to use progressbar2 >= 3.18.1

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,7 +14,7 @@ dependencies:
 - openssl=1.0.2g
 - pillow=3.2.0
 - pip=8.1.1
-- progressbar=2.3
+- progressbar2>=3.8.1
 - pyparsing=2.1.1
 - pyqt=4.11.4
 - python=2.7.11

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(  name = "OpenPIV",
         cmdclass = {'build_ext': build_ext},
         package_data = {'': package_data},
         data_files = data_files,
-        install_requires = ['scipy','numpy','cython','scikit-image >= 0.12.0'],
+        install_requires = ['scipy','numpy','cython','scikit-image >= 0.12.0','progressbar2 >= 3.8.1'],
         classifiers = [
         # PyPI-specific version type. The number specified here is a magic constant
         # with no relation to this application's version numbering scheme. *sigh*


### PR DESCRIPTION
which is good for both Python 2.7 and 3.6