### PR TITLE
3D-PIV Update

### DIFF
--- a/openpiv/PIV_3D_plotting.py
+++ b/openpiv/PIV_3D_plotting.py
@@ -10,7 +10,43 @@ from itertools import chain
 from mpl_toolkits.mplot3d import Axes3D
 
 
+def set_axes_equal(ax):
+    
+    '''
+    Following https://stackoverflow.com/questions/13685386/matplotlib-equal-unit-length-with-equal-aspect-ratio-z-axis-is-not-equal-to
+    Make axes of 3D plot have equal scale so that spheres appear as spheres,
+    cubes as cubes, etc..  This is one possible solution to Matplotlib's
+    ax.set_aspect('equal') and ax.axis('equal') not working for 3D.
+
+      Parameters
+    ----------
+     ax: matplotlib.axes object
+       
+     
+    '''
+
+    x_limits = ax.get_xlim3d()
+    y_limits = ax.get_ylim3d()
+    z_limits = ax.get_zlim3d()
+
+    x_range = abs(x_limits[1] - x_limits[0])
+    x_middle = np.mean(x_limits)
+    y_range = abs(y_limits[1] - y_limits[0])
+    y_middle = np.mean(y_limits)
+    z_range = abs(z_limits[1] - z_limits[0])
+    z_middle = np.mean(z_limits)
+
+    # The plot bounding box is a sphere in the sense of the infinity
+    # norm, hence I call half the max range the plot radius.
+    plot_radius = 0.5*max([x_range, y_range, z_range])
+
+    ax.set_xlim3d([x_middle - plot_radius, x_middle + plot_radius])
+    ax.set_ylim3d([y_middle - plot_radius, y_middle + plot_radius])
+    ax.set_zlim3d([z_middle - plot_radius, z_middle + plot_radius])
+
+
 def scatter_3D(a, cmap="jet", sca_args=None, control="color", size=60):
+    
     # default arguments for the quiver plot. can be overwritten by quiv_args
     if not isinstance(sca_args,dict):
         sca_args = {}
@@ -59,8 +95,6 @@ def scatter_3D(a, cmap="jet", sca_args=None, control="color", size=60):
         ax_scale.spines["top"].set_visible(False)
         ax_scale.tick_params(axis="both", which="both", labelbottom=False, labelleft=False, labelright=True,
                              bottom=False, left=False, right=True)
-
-        # implement marker scale bar
 
     ax.set_xlim(0, a.shape[0])
     ax.set_ylim(0, a.shape[1])
@@ -124,48 +158,71 @@ def plot_3D_alpha(data):
 
 
 def quiver_3D(u, v, w, x=None, y=None, z=None, mask_filtered=None, filter_def=0, filter_reg=(1, 1, 1),
-              cmap="jet", quiv_args=None, vmin=None, vmax=None):
-    """ Displaying 3D deformation fields vector arrows
+              cmap="jet", quiv_args=None, vmin=None, vmax=None, arrow_scale=0.15, equal_ax=True):
+    """ 
+    Displaying 3D deformation fields vector arrows
 
-       Parameters
-       ----------
-        u,v,w: 3d ndarray or lists
-            arrays or list with deformation in x,y and z direction
+    Parameters
+    ----------
+     u,v,w: 3d ndarray or lists
+         arrays or list with deformation in x,y and z direction
 
-        x,y,z: 3d ndarray or lists
-             Arrays or list with deformation the coordinates of the deformations.
-             Must match the dimensions of the u,v qnd w. If not provided x,y and z are created
-             with np.indices(u.shape)
+     x,y,z: 3d ndarray or lists
+          Arrays or list with deformation the coordinates of the deformations.
+          Must match the dimensions of the u,v qnd w. If not provided x,y and z are created
+          with np.indices(u.shape)
 
-        mask_filtered, boolean 3d ndarray or 1d ndarray
-             Array, or list with same dimensions as the deformations. Defines the area where deformations are drawn
-        filter_def: float
-             Filter that prevents the display of deformations arrows with length < filter_def
-        filter_reg: tuple
-             Filter that prevents the display of every i-th deformations arrows separatly alon each axis.
-             filter_reg=(2,2,2) means that only every second arrow along x,y z axis is displayed leading to
-             a total reduction of displayed arrows by a factor of 8.
-        cmap: string
-             matplotlib colorbar that defines the coloring of the arrow
-        quiv_args: dict
-            Dictionary with kwargs passed on to the matplotlib quiver function.
+     mask_filtered, boolean 3d ndarray or 1d ndarray
+          Array, or list with same dimensions as the deformations. Defines the area where deformations are drawn
+          
+     filter_def: float
+          Filter that prevents the display of deformations arrows with length < filter_def
+          
+     filter_reg: tuple,list or int
+          Filter that prevents the display of every i-th deformations arrows separatly alon each axis.
+          filter_reg=(2,2,2) means that only every second arrow along x,y z axis is displayed leading to
+          a total reduction of displayed arrows by a factor of 8. filter_reg=3 is interpreted
+          as (3,3,3).
+          
+     cmap: string
+          matplotlib colorbar that defines the coloring of the arrow
+          
+     quiv_args: dict
+         Dictionary with kwargs passed on to the matplotlib quiver function.
 
-        vmin,vmax: float
-            Upper and lower bounds for the colormap. Works like vmin and vmax in plt.imshow().
+     vmin,vmax: float
+         Upper and lower bounds for the colormap. Works like vmin and vmax in plt.imshow().
+         
+    arrow_scale: float
+        Automatic scaling of the quiver arrows so that the longest arrow has the 
+        length axis length * arrow_scale. Arrow length can alternatively be set by
+        passing a "lenght" argument in quiv_args. 
+    
+    equal_axes: bool
+        resize the figure axis so that they are have equal scaling.
+    
 
-       Returns
-       -------
-        fig: matploltib figure object
+    Returns
+    -------
+     fig: matploltib figure object
 
-        ax: mattplotlib axes object
-            the holding the main 3D quiver plot
+     ax: mattplotlib axes object
+         the holding the main 3D quiver plot
 
-       """
+    """
 
     # default arguments for the quiver plot. can be overwritten by quiv_args
-    quiver_args = {"normalize": False, "alpha": 0.8, "pivot": 'tail', "linewidth": 1, "length": 20}
+    quiver_args = {"normalize":False, "alpha":0.8, "pivot":'tail', "linewidth":1, "length":1}
     if isinstance(quiv_args, dict):
         quiver_args.update(quiv_args)
+    # overwriting length if an arrow scale and a "length" argument in quiv_args 
+    # is provided at the same
+    if arrow_scale is not None:
+        quiver_args["length"] = 1
+        
+    # convert filter ot list if proveided as int    
+    if not isinstance(filter_reg, (tuple, list)):
+        filter_reg = [filter_reg] * 3
 
     # generating coordinates if not provided
     if x is None:
@@ -183,19 +240,13 @@ def quiver_3D(u, v, w, x=None, y=None, z=None, mask_filtered=None, filter_def=0,
     # conversion to array
     x, y, z = np.array([x, y, z])
 
-    # filtering arrows for the display
     deformation = np.sqrt(u ** 2 + v ** 2 + w ** 2)
     if not isinstance(mask_filtered, np.ndarray):
         mask_filtered = deformation > filter_def
         if isinstance(filter_reg, list):
             show_only = np.zeros(u.shape).astype(bool)
-            if len(filter_reg) == 1:
-                show_only[::filter_reg[0]] = True
-            elif len(filter_reg) == 3:
-                show_only[::filter_reg[0], ::filter_reg[1], ::filter_reg[2]] = True
-            else:
-                raise ValueError(
-                    "filter_reg data has wrong length (%s). Use list with length 1 or 3." % str(len(filter_reg.shape)))
+            # filtering out every x-th
+            show_only[::filter_reg[0], ::filter_reg[1], ::filter_reg[2]] = True
             mask_filtered = np.logical_and(mask_filtered, show_only)
 
     xf = x[mask_filtered]
@@ -206,37 +257,51 @@ def quiver_3D(u, v, w, x=None, y=None, z=None, mask_filtered=None, filter_def=0,
     wf = w[mask_filtered]
     df = deformation[mask_filtered]
 
+    # make cmap
     # create normalized color map for arrows
-    norm = matplotlib.colors.Normalize(vmin=vmin, vmax=vmax)
+    norm = matplotlib.colors.Normalize(vmin=vmin, vmax=vmax)  # 10 ) #cbound[1] ) #)
     sm = matplotlib.cm.ScalarMappable(cmap=cmap, norm=norm)
     sm.set_array([])
-    cm = matplotlib.cm.get_cmap(cmap)
-    colors = cm(norm(df))  #
+    # different option
+    colors = matplotlib.cm.jet(norm(df))  #
 
     colors = [c for c, d in zip(colors, df) if d > 0] + list(chain(*[[c, c] for c, d in zip(colors, df) if d > 0]))
     # colors in ax.quiver 3d is really fucked up/ will probably change with updates:
     # requires list with: first len(u) entries define the colors of the shaft, then the next len(u)*2 entries define
-    # the color of left and right arrow head side in alternating order. Try for example:
+    # the color ofleft and right arrow head side in alternating order. Try for example:
     # colors = ["red" for i in range(len(cf))] + list(chain(*[["blue", "yellow"] for i in range(len(cf))]))
     # to see this effect.
-    # BUT WAIT THERE'S MORE: zero length arrows are apparently filtered out in the matplolib with out
-    # filtering the color list appropriately so we have to do this ourselfs as well
+    # BUT WAIT THERS MORE: zeor length arrows are apparently filtered out in the matplolib with out filtering 
+    # the color list appropriately so we have to do this our selfs as well
+
+    # scale arrows to axis dimensions:
+    ax_dims = [(x.min(), x.max()), (y.min(), y.max()), (z.min(), z.max())]
+    if arrow_scale is not None:
+        max_length = df.max()
+        max_dim_length= np.max([(d[1] - d[0] + 1) for d in ax_dims] )
+        scale = max_dim_length * arrow_scale / max_length
+    else:
+        scale = 1
 
     # plotting
     fig = plt.figure()
     ax = fig.gca(projection='3d', rasterized=True)
-
-    ax.quiver(xf, yf, zf, vf, uf, wf, colors=colors, **quiv_args)
+    ax.quiver(xf, yf, zf, vf*scale, uf*scale, wf*scale, colors=colors, **quiver_args)
     plt.colorbar(sm)
 
-    ax.set_xlim(x.min(), x.max())
-    ax.set_ylim(y.min(), y.max())
-    ax.set_zlim(z.min(), z.max())
+    ax.set_xlim(ax_dims[0])
+    ax.set_ylim(ax_dims[1])
+    ax.set_zlim(ax_dims[2])
+
+    if equal_ax:
+        set_axes_equal(ax)
+
     ax.set_xlabel("x")
     ax.set_ylabel("y")
     ax.set_zlabel("z")
     ax.w_xaxis.set_pane_color((0.2, 0.2, 0.2, 1.0))
     ax.w_yaxis.set_pane_color((0.2, 0.2, 0.2, 1.0))
     ax.w_zaxis.set_pane_color((0.2, 0.2, 0.2, 1.0))
+    
+    return fig
 
-    return fig, ax

--- a/openpiv/examples/notebooks/PIV_3D_example.ipynb
+++ b/openpiv/examples/notebooks/PIV_3D_example.ipynb
@@ -441,7 +441,7 @@
    "outputs": [],
    "source": [
     "# 3D PIV\n",
-    "u, v, w, sig2noise = extended_search_area_piv3D(alive, relax, window_size=window_size, overlap=overlap,\n",
+    "u, v, w, sig2noise = extended_search_area_piv3D(relax, alive, window_size=window_size, overlap=overlap,\n",
     "                                                search_area_size=search_area, dt=(1 / du, 1 / dv, 1 / dw),\n",
     "                                                subpixel_method='gaussian',\n",
     "                                                sig2noise_method='peak2peak',\n",
@@ -600,9 +600,9 @@
    "notebook_metadata_filter": "-all"
   },
   "kernelspec": {
-   "display_name": "Python [conda env:test] *",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-test-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -614,7 +614,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.9"
   }
  },
  "nbformat": 4,

--- a/openpiv/examples/notebooks/PIV_3D_example.md
+++ b/openpiv/examples/notebooks/PIV_3D_example.md
@@ -203,7 +203,7 @@ for i, im in enumerate(images):
 
 ```python
 # 3D PIV
-u, v, w, sig2noise = extended_search_area_piv3D(alive, relax, window_size=window_size, overlap=overlap,
+u, v, w, sig2noise = extended_search_area_piv3D(relax, alive, window_size=window_size, overlap=overlap,
                                                 search_area_size=search_area, dt=(1 / du, 1 / dv, 1 / dw),
                                                 subpixel_method='gaussian',
                                                 sig2noise_method='peak2peak',

--- a/openpiv/examples/notebooks/PIV_3D_example.py
+++ b/openpiv/examples/notebooks/PIV_3D_example.py
@@ -189,7 +189,7 @@ for i, im in enumerate(images):
 
 # %%
 # 3D PIV
-u, v, w, sig2noise = extended_search_area_piv3D(alive, relax, window_size=window_size, overlap=overlap,
+u, v, w, sig2noise = extended_search_area_piv3D(relax, alive, window_size=window_size, overlap=overlap,
                                                 search_area_size=search_area, dt=(1 / du, 1 / dv, 1 / dw),
                                                 subpixel_method='gaussian',
                                                 sig2noise_method='peak2peak',

--- a/openpiv/pyprocess3D.py
+++ b/openpiv/pyprocess3D.py
@@ -2,6 +2,7 @@ import numpy.lib.stride_tricks
 import numpy as np
 from numpy.fft import rfftn, irfftn
 from numpy import ma
+from tqdm import tqdm
 
 """This module contains a pure python implementation of the basic
 cross-correlation algorithm for PIV image processing."""
@@ -555,7 +556,7 @@ def extended_search_area_piv3D(
     # loop over the interrogation windows
     # i, j are the row, column indices of the center of each interrogation
     # window
-    for k in range(field_shape[0]):
+    for k in tqdm(range(field_shape[0])):
         for m in range(field_shape[1]):
             for l in range(field_shape[2]):
 

--- a/openpiv/pyprocess3D.py
+++ b/openpiv/pyprocess3D.py
@@ -611,7 +611,7 @@ def extended_search_area_piv3D(
                     z -= (search_area_size[2] + window_size[2] - 1) // 2
 
                     # get displacements, apply coordinate system definition
-                    u[k, m, l], v[k, m, l], w[k, m, l] = -col, row, z
+                    u[k, m, l], v[k, m, l], w[k, m, l] = col, -row, -z
 
                     # get signal to noise ratio
                     if sig2noise_method is not None:

--- a/openpiv/test/test_pyprocess3D.py
+++ b/openpiv/test/test_pyprocess3D.py
@@ -33,9 +33,9 @@ def test_piv():
     """
     frame_a, frame_b = create_pair(image_size=32)
     u, v, w = extended_search_area_piv3D(frame_a, frame_b, window_size=(10, 10, 10), search_area_size=(10, 10, 10))
-    assert (dist(u, 3) < threshold)
-    assert (dist(v, -2) < threshold)
-    assert (dist(w, -1) < threshold)
+    assert (dist(u, -3) < threshold)
+    assert (dist(v, 2) < threshold)
+    assert (dist(w, 1) < threshold)
 
 
 def test_piv_extended_search_area():
@@ -45,6 +45,6 @@ def test_piv_extended_search_area():
     """
     frame_a, frame_b = create_pair(image_size=32)
     u, v, w = extended_search_area_piv3D(frame_a, frame_b, window_size=(10, 10, 10), search_area_size=(15, 15, 15))
-    assert (dist(u, 3) < threshold)
-    assert (dist(v, -2) < threshold)
-    assert (dist(w, -1) < threshold)
+    assert (dist(u, -3) < threshold)
+    assert (dist(v, 2) < threshold)
+    assert (dist(w, 1) < threshold)

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,8 @@ setup(
         'scipy',
         'natsort',
         'GitPython',
-        'pytest'
+        'pytest',
+		'tqdm'
     ],
     classifiers = [
         # PyPI-specific version type. The number specified here is a magic constant


### PR DESCRIPTION
Dear Alex,

We have some minor updates for 3D PIV:

- First, we noticed that the signs of the output deformation field did not match the conversion of 2D-PIV: In 2D-PIV the deformations in x-direction (v) have a positiv sign for movements to higher x-positions, whereas deformation in y-direction have a negative sign for movements to higher y-positions. We now matched the 3D-PIV fields to this convention: Deformations in x- and z-direction have a positive sign and deformations in y-direction have a negative sign. 

- Second, we added a progress bar to the calculation of the 3D deformation fields - a usefull feature for long calculations.

- Third, we updated the plotting-function. We added an option that automatically scales the arrow-size to the axis-length. Additionally, we added a function to stretch the figure axes so that they all have the same scale. 

Best, 

Andreas&David