### PR TITLE
docs(get_field_shape): Correct docstring

### DIFF
--- a/openpiv/pyprocess.py
+++ b/openpiv/pyprocess.py
@@ -51,7 +51,7 @@ def get_field_shape(image_size, search_area_size, overlap):
 
     Returns
     -------
-    field_shape : three elements tuple
+    field_shape : 2-element tuple
         the shape of the resulting flow field
     """
     field_shape = (np.array(image_size) - np.array(search_area_size)) // (


### PR DESCRIPTION
2-element tuple, not a 3-element tuple.

See usage in https://github.com/OpenPIV/openpiv-python/blob/7852c9fc5d4e6bb51da64df8e4f48407bd6e464e/openpiv/pyprocess.py#L986,
which unpacks a 2-element tuple into 2 vars.