### PR TITLE
Clean dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ requires = [
     # The minimum setuptools version is specific to the PEP 517 backend,
     # and may be stricter than the version required in `setup.py`
     "setuptools>=40.6.0",
-    "wheel",
-    "numpy"
+    "wheel"
 ]
 build-backend = "setuptools.build_meta"

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,2 +1,0 @@
-"%PYTHON%" setup.py install --single-version-externally-managed --record=record.txt
-if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,1 +1,0 @@
-$PYTHON setup.py install --single-version-externally-managed --record=record.txt  # Python command to install the script.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,29 +1,31 @@
+{% set data = load_setup_py_data(setup_file="../setup.py",
+  from_recipe_dir=True) %}
+
 package:
   name: openpiv
-  version: "0.24.2"
+  version: {{ data.get('version') }}
 
 source:
-  git_rev: 0.24.2
-  git_url: https://github.com/openpiv/openpiv-python.git
+  path: ..
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   build:
-    - python
+    - python >=3.7
     - pip
-    - setuptools
-    - numpy
-    - requests
-    - matplotlib
-    - scipy
-    - pillow
-    - imageio
-    - tqdm
   run:
-    - python
+    - python >=3.7
     - numpy
-    - scipy
-    - matplotlib
+    - imageio
+    - matplotlib-base
     - scikit-image
+    - scipy
+    - natsort
+    - tqdm
 
 test:
   imports:

--- a/setup.py
+++ b/setup.py
@@ -25,11 +25,9 @@ setup(
         'scikit-image',
         'scipy',
         'natsort',
-        'GitPython',
-        'pytest',
-        'watermark',
         'tqdm'
     ],
+    extras_require={"tests": ["pytest"]},
     classifiers=[
         # PyPI-specific version type. The number specified here is a magic
         # constant

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name="OpenPIV",
-    version='0.24.2',
+    version='0.24.3',
     packages=find_packages(),
     include_package_data=True,
     long_description=long_description,


### PR DESCRIPTION
- pytest is only required to run the tests (added to extras_require: you can run `pip install opnepiv[tests]` to install pytest at the same time)
- I didn't see watermark or GitPython used - removed them
- Removed numpy from setup requires in pyproject.toml

I also cleaned the local conda recipe (not sure if you want to keep it as you have it on conda-forge) so you don't have to bump the version in both setup.py and meta.yaml.

And I bumped the version.