### PR TITLE
Fixed minor bug in local variance normalization

### DIFF
--- a/openpiv/preprocess.py
+++ b/openpiv/preprocess.py
@@ -307,7 +307,7 @@ def local_variance_normalization(img, sigma_1 = 2, sigma_2 = 1, clip = True):
         a filtered two dimensional array of the input image
     
     """
-    high_pass = high_pass(img, sigma_1, False)
+    high_pass = img - gaussian_filter(img, sigma_1)
     img_blur = gaussian_filter(high_pass * high_pass, sigma = sigma_2)
     den = np.sqrt(img_blur)
     img = np.divide( # stops image from being all black


### PR DESCRIPTION
## New:
 + None

## Changed:
 + local variance normalization filter in `preprocess` module
 + trailing white space at the end of function docs

## Notes:
 + On the local variance normalization filter, more specifically [this line](https://github.com/OpenPIV/openpiv-python/blob/6b347b06a66bfc534666d7d2bf7ce9ad114e8b34/openpiv/preprocess.py#L308), there was a bug encountered when the denominator array `den` had zeros causing the filtered image to be filled with zeros. This was fixed by using `numpy.divide()`.
+ A small performance increase in the local variance normalization filter occured as a result by changing https://github.com/OpenPIV/openpiv-python/blob/6b347b06a66bfc534666d7d2bf7ce9ad114e8b34/openpiv/preprocess.py#L307 to https://github.com/ErichZimmer/openpiv-python/blob/4ae3486cadad0b2027f5e329be729eb280f4b1a9/openpiv/preprocess.py#L312
+ flag parameter in  local variance normalization filter was updated, breaking compatibility with its previous version (need to update examples notebooks)
+ There appears to be a lock of uniform structure in the documentation. For instance, some function docs follow NumPy's documentation guidelines while others don't. Should this be of concern?

