### PR TITLE
suggest to modify peak2peak condition

### DIFF
--- a/openpiv/pyprocess.py
+++ b/openpiv/pyprocess.py
@@ -501,12 +501,20 @@ def sig2noise_ratio(correlation, sig2noise_method="peak2peak", width=2):
                     corr, peak1_i, peak1_j, width=width
                 )
 
-                condition = (
-                    corr_max2 == 0
-                    or peak2_i == 0
+                border_condition = (
+                    peak2_i == 0
                     or peak2_i == corr.shape[0] - 1
                     or peak2_j == 0
                     or peak2_j == corr.shape[1] - 1
+                )
+
+                condition = (
+                    # non-valid second peak
+                    corr_max2 == 0
+                    or (
+                    # maybe a valid peak at the border, bad sign
+                    border_condition and corr_max2 > 0.5*corr_max1[i]
+                    )
                 )
                 if condition:  # mark failed peak2
                     corr_max2 = np.nan


### PR DESCRIPTION
in our case, when we test synthetic images, most of them have a single peak only and then the second, minor, not dangerous second peak is often on the border. this condition just randomly kills good vectors that have a clear 1  large peak at the right shift.