### PR TITLE
Scaling adjustments for windef and output notation

### DIFF
--- a/openpiv/test/test_tools.py
+++ b/openpiv/test/test_tools.py
@@ -43,7 +43,7 @@ def test_display_vector_field(file_a=_file_a, file_b=_file_b, test_file=_test_fi
     display_vector_field('tmp.txt', on_img=True, image_name=file_a, ax=ax)
     decorators.remove_ticks_and_titles(fig)
     fig.savefig('./tmp.png')
-    res = compare.compare_images('./tmp.png', test_file, 0.001)
+    res = compare.compare_images('./tmp.png', test_file, 0.05)
     assert res is None
 
 def test_file_patterns():

--- a/openpiv/tools.py
+++ b/openpiv/tools.py
@@ -329,7 +329,7 @@ def find_boundaries(threshold, list_img1, list_img2, filename, picname):
     return list_bound
 
 
-def save(x, y, u, v, mask, filename, fmt="%8.4f", delimiter="\t"):
+def save(x, y, u, v, mask, filename, fmt="%.4e", delimiter="\t"):
     """Save flow field to an ascii file.
 
     Parameters

--- a/openpiv/windef.py
+++ b/openpiv/windef.py
@@ -321,6 +321,9 @@ def piv(settings):
         u = u.filled(0.)
         v = v.filled(0.)
 
+        # pixel / frame -> pixel / second
+        u /= settings.dt 
+        v /= settings.dt
         # "scales the results pixel-> meter"
         x, y, u, v = scaling.uniform(x, y, u, v,
                                      scaling_factor=settings.scaling_factor)


### PR DESCRIPTION
I adjusted the scaling such that the velocities are in meters per second and not meters per frame (done in old and original windef, I am not sure why not in the current). Additionally, to make full use of this change I changed the output to use scientific notations.

In particular, I had the problem that the velocity scales where completely off. When corrected, I run into the problem of experiments with low velocities having these cut off. These changes fix these issues.