### PR TITLE
remove unused parameter from sig2noise_val

### DIFF
--- a/openpiv/validation.py
+++ b/openpiv/validation.py
@@ -132,18 +132,9 @@ def sig2noise_val(
 
     Parameters
     ----------
-    u : 2d or 3d np.ndarray
-        a two or three dimensional array containing the u velocity component.
-
-    v : 2d or 3d np.ndarray
-        a two or three dimensional array containing the v velocity component.
-
     s2n : 2d np.ndarray
         a two or three dimensional array containing the value  of the signal to
         noise ratio from cross-correlation function.
-    w : 2d or 3d np.ndarray
-        a two or three dimensional array containing the w (in z-direction)
-        velocity component.
 
     threshold: float
         the signal to noise ratio threshold value.


### PR DESCRIPTION
Hi, 

Thanks for creating this repository! I’ve found minor issue with the docstring of the function `sig2noise_val`.
Hope this helps and let me know if you have any concerns. 

Best,
