### PR TITLE
Normalized median filter is added to `windef.py`.

### DIFF
--- a/openpiv/validation.py
+++ b/openpiv/validation.py
@@ -408,13 +408,22 @@ def typical_validation(
     #     plt.quiver(u,v,color='k')
     
 
-    flag_m = local_median_val(
-        u,
-        v,
-        u_threshold=settings.median_threshold,
-        v_threshold=settings.median_threshold,
-        size=settings.median_size,
-    )
+    if settings.median_normalized:
+        flag_m = local_norm_median_val(
+            u, 
+            v, 
+            ε=0.2, # use the recomended value at this point, later add user's input for this
+            threshold=settings.median_threshold,
+            size=settings.median_size
+        )
+    else:
+        flag_m = local_median_val(
+            u,
+            v,
+            u_threshold=settings.median_threshold,
+            v_threshold=settings.median_threshold,
+            size=settings.median_size,
+        )
     
     # u[flag_m] = np.ma.masked
     # v[flag_m] = np.ma.masked

--- a/openpiv/windef.py
+++ b/openpiv/windef.py
@@ -129,11 +129,12 @@ class PIVSettings:
     min_max_v_disp: Tuple=(-30, 30)
     # The second filter is based on the global STD threshold
     std_threshold: int=10  # threshold of the std validation
-    # The third filter is the median test (not normalized at the moment)
+    # The third filter is the median test: pick between normalized and regular
+    median_normalized: bool=False # False = do regular median, True = do normalized median
     median_threshold: int=3  # threshold of the median validation
+    median_size: int=1  # defines the size of the local median
     # On the last iteration, an additional validation can be done based on
     # the S/N.
-    median_size: int=1  # defines the size of the local median
 
 
 


### PR DESCRIPTION
I added normalized median filter to `windef.py`: I created a new setting in the settings class and I added an if statement to the `typical_val()` function in `validation.py`. I.e., right now it is either regular or normalized filter, you can't do both. I was thinking about it and decided it is a better way. I ran it a couple of times on my own Ph.D. data set. Everything works.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add a normalized median filter option to the PIVSettings class in `windef.py` and update the `typical_validation` function in `validation.py` to support this new filter type, allowing users to select between regular and normalized median filtering.

New Features:
- Introduce a normalized median filter option in the `windef.py` settings, allowing users to choose between regular and normalized median filtering.

Enhancements:
- Modify the `typical_validation` function in `validation.py` to incorporate the new normalized median filter option based on the settings.

<!-- Generated by sourcery-ai[bot]: end summary -->