### PR TITLE
fix: apply validity flag in vectorized_sig2noise_ratio

### DIFF
--- a/openpiv/pyprocess.py
+++ b/openpiv/pyprocess.py
@@ -646,7 +646,7 @@ def vectorized_sig2noise_ratio(correlation,
             out=np.zeros_like(peaks1),
             where=(peaks2 > 0.0)
         )
-        peak2peak[flag is True] = 0 # replace invalid values
+        peak2peak[flag] = 0  # replace invalid values
         return peak2peak
     
     elif sig2noise_method == "peak2mean":
@@ -667,7 +667,7 @@ def vectorized_sig2noise_ratio(correlation,
             out=np.zeros_like(peaks1max),
             where=(peaks2mean > 0.0)
         )
-        peak2mean[flag is True] = 0 # replace invalid values
+        peak2mean[flag] = 0  # replace invalid values
         return peak2mean
     else:
         raise ValueError(f"sig2noise_method not supported: {sig2noise_method}")

--- a/openpiv/test/test_pyprocess.py
+++ b/openpiv/test/test_pyprocess.py
@@ -213,31 +213,39 @@ def test_find_subpixel_peak_position():
         find_subpixel_peak_position(corr_gauss, subpixel_method="invalid_method")
 
 def test_vectorized_sig2noise_ratio():
-    """Test vectorized_sig2noise_ratio function"""
-    # Create a simple correlation map with a clear peak
-    corr = np.zeros((3, 5, 5))
+    """Test vectorized_sig2noise_ratio function
 
-    # First correlation map: clear peak
-    corr[0, 2, 2] = 1.0
-    corr[0, :2, :] = 0.1
-    corr[0, 3:, :] = 0.1
+    The correlation maps are 16 x 16 with all peaks away from the map
+    borders, so no window trips the validity flag (weak or border peaks)
+    and every ratio stays positive.
+    """
+    corr = np.full((3, 16, 16), 0.05)
 
-    # Second correlation map: two peaks
-    corr[1, 2, 2] = 1.0
-    corr[1, 0, 0] = 0.5
+    # First correlation map: clear peak, faint interior second peak
+    corr[0, 8, 8] = 1.0
+    corr[0, 4, 4] = 0.1
 
-    # Third correlation map: noisy
-    corr[2, 2, 2] = 0.3
-    corr[2] = corr[2] + 0.1
+    # Second correlation map: two interior peaks; the secondary one at
+    # (8, 10) sits inside the width=2 exclusion box but outside the
+    # width=1 box, so the ratio must depend on the chosen width
+    corr[1, 8, 8] = 1.0
+    corr[1, 8, 10] = 0.5
+    corr[1, 4, 4] = 0.3
+
+    # Third correlation map: noisy, two interior peaks of similar height
+    corr[2, 8, 8] = 0.4
+    corr[2, 4, 12] = 0.35
 
     # Test peak2peak method
     s2n_p2p = vectorized_sig2noise_ratio(corr, sig2noise_method='peak2peak', width=1)
     assert s2n_p2p.shape == (3,)
+    assert np.all(s2n_p2p > 0)  # no window is flagged
     assert s2n_p2p[0] > s2n_p2p[2]  # Clear peak should have higher S2N than noisy
 
     # Test peak2mean method
     s2n_p2m = vectorized_sig2noise_ratio(corr, sig2noise_method='peak2mean')
     assert s2n_p2m.shape == (3,)
+    assert np.all(s2n_p2m > 0)  # no window is flagged
     assert s2n_p2m[0] > s2n_p2m[2]  # Clear peak should have higher S2N than noisy
 
     # Test with different width
@@ -248,6 +256,45 @@ def test_vectorized_sig2noise_ratio():
     # Test with invalid method
     with pytest.raises(Exception):
         vectorized_sig2noise_ratio(corr, sig2noise_method='invalid_method')
+
+def test_vectorized_sig2noise_ratio_flags_invalid_windows():
+    """Windows failing the validity checks must return a zero ratio.
+
+    Regression test: ``peak2peak[flag is True] = 0`` indexed with the
+    Python expression ``flag is True`` (a constant ``False``), which numpy
+    treats as an empty boolean mask, so the flag was silently never
+    applied and invalid windows leaked raw ratios.
+    """
+    corr = np.full((4, 16, 16), 0.05)
+
+    # Window 0: healthy interior peaks -> must stay positive
+    corr[0, 8, 8] = 1.0
+    corr[0, 4, 4] = 0.5
+
+    # Window 1: first peak on the map border
+    corr[1, 0, 5] = 1.0
+    corr[1, 8, 8] = 0.5
+
+    # Window 2: no signal (first peak below the 1e-3 threshold)
+    corr[2] = 1e-5
+    corr[2, 8, 8] = 5e-4
+
+    # Window 3: healthy first peak but second peak on the map border
+    corr[3, 8, 8] = 1.0
+    corr[3, 0, 3] = 0.9
+
+    s2n_p2p = vectorized_sig2noise_ratio(corr, sig2noise_method='peak2peak', width=1)
+    assert s2n_p2p[0] > 0
+    assert s2n_p2p[1] == 0  # border first peak
+    assert s2n_p2p[2] == 0  # no signal
+    assert s2n_p2p[3] == 0  # border second peak
+
+    # peak2mean only checks the first peak
+    s2n_p2m = vectorized_sig2noise_ratio(corr, sig2noise_method='peak2mean')
+    assert s2n_p2m[0] > 0
+    assert s2n_p2m[1] == 0  # border first peak
+    assert s2n_p2m[2] == 0  # no signal
+    assert s2n_p2m[3] > 0  # second peak is irrelevant for peak2mean
 
 def test_fft_correlate_images():
     """Test fft_correlate_images function"""


### PR DESCRIPTION
Fixes #368.

## What

`vectorized_sig2noise_ratio` builds a per-window validity flag (weak first peak, border first peak, and for `peak2peak` a weak/border second peak) but never applies it:

```python
peak2peak[flag is True] = 0   # 'flag is True' is the constant False -> empty mask -> no-op
```

This PR indexes with the flag array itself (`peak2peak[flag] = 0`, `peak2mean[flag] = 0`), so invalid windows return 0 as intended and as the loop-based `sig2noise_ratio` already does.

## Test changes

- `test_vectorized_sig2noise_ratio` passed only because of the no-op: its 5×5 correlation maps are so small that the second peak always lands on the map border, so with the flag applied every `peak2peak` ratio in that test becomes 0 and the `s2n[0] > s2n[2]` assertion fails. Rebuilt on 16×16 maps with interior peaks (same assertions, plus `> 0` checks that no window is flagged).
- Added `test_vectorized_sig2noise_ratio_flags_invalid_windows` covering: healthy window stays positive, border first peak → 0, no-signal window → 0, border second peak → 0 for `peak2peak` (and correctly *not* zeroed for `peak2mean`).

## Behavior change note

Downstream code thresholding on s2n (e.g. `validation.sig2noise_val`) will now correctly reject windows the function always meant to reject; previously those leaked raw ratios. Note the vectorized flag is stricter than the loop-based `sig2noise_ratio` (which rejects a border second peak only when `corr_max2 > 0.5 * corr_max1`); aligning those two semantics is left to a separate discussion, as noted in #368.

## Verification

`test_pyprocess.py` (12), `test_process.py` + `test_validation.py` + `test_lib.py` (37) all pass locally against the patched source (numpy 1.x, CPU).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure vectorized signal-to-noise ratio computation correctly zeroes out invalid windows and strengthen its regression test coverage.

Bug Fixes:
- Apply the validity flag when computing vectorized peak2peak and peak2mean signal-to-noise ratios so invalid correlation windows return zero as intended.

Tests:
- Rework vectorized_sig2noise_ratio tests to use larger correlation maps with interior peaks, ensuring ratios remain positive when no window is flagged.
- Add regression tests verifying that windows with border or weak peaks and no-signal cases are flagged and produce zero signal-to-noise ratios for the appropriate methods.